### PR TITLE
Artifact ID encoding is switched to hex

### DIFF
--- a/.changeset/clever-terms-tell.md
+++ b/.changeset/clever-terms-tell.md
@@ -1,0 +1,5 @@
+---
+"hardhat-soko": patch
+---
+
+change encoding of id to hex

--- a/src/scripts/local-storage-provider.ts
+++ b/src/scripts/local-storage-provider.ts
@@ -152,7 +152,7 @@ export class LocalStorageProvider {
     );
     const hash = crypto.createHash("sha256");
     hash.update(artifactContent);
-    return hash.digest("base64").substring(0, 12);
+    return hash.digest("hex").substring(0, 12);
   }
 
   private exists(path: string): Promise<boolean> {

--- a/src/scripts/push.ts
+++ b/src/scripts/push.ts
@@ -59,7 +59,7 @@ export async function pushArtifact(
 
   const hash = crypto.createHash("sha256");
   hash.update(freshBuildInfoResult.value.content);
-  const checksum = hash.digest("base64");
+  const checksum = hash.digest("hex");
   const artifactId = checksum.substring(0, 12);
 
   const pushResult = await toAsyncResult(


### PR DESCRIPTION
## Summary

Artifact ID now uses `hex` for encoding